### PR TITLE
Allow users to select devices to track

### DIFF
--- a/custom_components/pfsense/binary_sensor.py
+++ b/custom_components/pfsense/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNKNOWN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify
 
@@ -25,6 +25,7 @@ async def async_setup_entry(
 ):
     """Set up the pfSense binary sensors."""
 
+    @callback
     def process_entities_callback(hass, config_entry):
         data = hass.data[DOMAIN][config_entry.entry_id]
         coordinator = data[COORDINATOR]
@@ -33,7 +34,7 @@ async def async_setup_entry(
             config_entry,
             coordinator,
             BinarySensorEntityDescription(
-                key=f"carp.status",
+                key="carp.status",
                 name="CARP Status",
                 # native_unit_of_measurement=native_unit_of_measurement,
                 icon="mdi:gauge",

--- a/custom_components/pfsense/const.py
+++ b/custom_components/pfsense/const.py
@@ -26,7 +26,7 @@ PLATFORMS = ["sensor", "switch", "device_tracker", "binary_sensor"]
 LOADED_PLATFORMS = "loaded_platforms"
 
 PFSENSE_CLIENT = "pfsense_client"
-
+SHOULD_RELOAD = "should_reload"
 COORDINATOR = "coordinator"
 DEVICE_TRACKER_COORDINATOR = "device_tracker_coordinator"
 DEFAULT_SCAN_INTERVAL = 30
@@ -39,6 +39,9 @@ DEFAULT_DEVICE_TRACKER_ENABLED = False
 
 CONF_DEVICE_TRACKER_SCAN_INTERVAL = "device_tracker_scan_interval"
 DEFAULT_DEVICE_TRACKER_SCAN_INTERVAL = 60
+
+CONF_DEVICES = "devices"
+CONF_PREVIOUS_DEVICES = "previous_devices"
 
 COUNT = "count"
 

--- a/custom_components/pfsense/device_tracker.py
+++ b/custom_components/pfsense/device_tracker.py
@@ -1,31 +1,53 @@
 """Support for tracking for pfSense devices."""
 from __future__ import annotations
 
+import logging
+from typing import Any, Mapping
+
 from homeassistant.components.device_tracker import SOURCE_TYPE_ROUTER
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers import entity_platform
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    async_get as async_get_dev_reg,
+)
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_registry import async_get as async_get_ent_reg
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify
 from mac_vendor_lookup import AsyncMacLookup
 
 from . import CoordinatorEntityManager, PfSenseEntity, dict_get
-from .const import DEVICE_TRACKER_COORDINATOR, DOMAIN, PFSENSE_CLIENT
-from .utils import add_method
+from .const import (
+    CONF_DEVICES,
+    DEVICE_TRACKER_COORDINATOR,
+    DOMAIN,
+    PFSENSE_CLIENT,
+    SHOULD_RELOAD,
+)
+
+_LOGGER = logging.getLogger(__name__)
 
 
-@add_method(AsyncMacLookup)
-def sync_lookup(self, mac):
-    mac = self.sanitise(mac)
+def lookup_mac(mac_vendor_lookup: AsyncMacLookup, mac: str) -> str:
+    mac = mac_vendor_lookup.sanitise(mac)
     if type(mac) == str:
         mac = mac.encode("utf8")
-    return self.prefixes[mac[:6]].decode("utf8")
+    return mac_vendor_lookup.prefixes[mac[:6]].decode("utf8")
+
+
+def get_device_tracker_unique_id(mac: str, netgate_id: str):
+    """Generate device_tracker unique ID."""
+    return slugify(f"{netgate_id}_mac_{mac}")
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: entity_platform.AddEntitiesCallback,
 ) -> None:
     """Set up device tracker for pfSense component."""
     mac_vendor_lookup = AsyncMacLookup()
@@ -37,7 +59,14 @@ async def async_setup_entry(
         except:
             pass
 
-    def process_entities_callback(hass, config_entry):
+    store = Store(hass, 1, DOMAIN)
+    cache_data = await store.async_load() or {}
+    ent_reg = async_get_ent_reg(hass)
+
+    @callback
+    def process_entities_callback(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> list[PfSenseScannerEntity]:
         # options = config_entry.options
         data = hass.data[DOMAIN][config_entry.entry_id]
         coordinator = data[DEVICE_TRACKER_COORDINATOR]
@@ -48,29 +77,71 @@ async def async_setup_entry(
 
         entities = []
         entries = dict_get(state, "arp_table")
-        if isinstance(entries, list):
-            for entry in entries:
-                entry_mac = entry.get("mac-address")
-                if entry_mac is None:
-                    continue
+        if not entries:
+            return []
 
-                entry_mac = entry_mac.lower()
-                mac_vendor = None
-                try:
-                    mac_vendor = mac_vendor_lookup.sync_lookup(entry_mac)
-                except:
-                    pass
+        whitelisted_devices = config_entry.options.get(CONF_DEVICES)
+        if whitelisted_devices:
+            enabled_default = True
 
-                entity = PfSenseScannerEntity(
-                    config_entry,
-                    coordinator,
-                    enabled_default,
+        mac_entries = [
+            entry_mac.lower()
+            for entry in entries
+            if (entry_mac := entry.get("mac-address"))
+            and (not whitelisted_devices or entry_mac in whitelisted_devices)
+        ]
+        mac_entries_missing_from_arp = list(set(cache_data.keys()) - set(mac_entries))
+        for entry_mac in [*mac_entries, *mac_entries_missing_from_arp]:
+            if enabled_default and entry_mac not in whitelisted_devices:
+                continue
+
+            mac_vendor = None
+            try:
+                mac_vendor = lookup_mac(mac_vendor_lookup, entry_mac)
+            except:
+                pass
+
+            if entry_mac in mac_entries_missing_from_arp:
+                _LOGGER.debug(
+                    (
+                        "Creating an entity with the last known state for mac %s "
+                        "because it's not in the ARP table"
+                    ),
                     entry_mac,
-                    mac_vendor,
                 )
-                entities.append(entity)
 
-        return entities
+            entity = PfSenseScannerEntity(
+                hass,
+                config_entry,
+                coordinator,
+                enabled_default,
+                entry_mac,
+                mac_vendor,
+                cache_data.get(entry_mac),
+            )
+
+            entities.append(entity)
+            cache_data[entry_mac] = {
+                "extra_state_attributes": entity._extra_state_attributes,
+                "ip_address": entity._ip_address,
+                "hostname": entity._hostname,
+            }
+
+            if not enabled_default:
+                continue
+
+            entity_id = ent_reg.async_get_entity_id(
+                "device_tracker", DOMAIN, entity.unique_id
+            )
+            if (
+                entity_id
+                and (entity_entry := ent_reg.async_get(entity_id))
+                and entity_entry.disabled
+            ):
+                ent_reg.async_update_entity(entity_id, disabled_by=None)
+                hass.data[DOMAIN][config_entry.entry_id][SHOULD_RELOAD] = True
+
+        return entities, cache_data
 
     cem = CoordinatorEntityManager(
         hass,
@@ -78,8 +149,25 @@ async def async_setup_entry(
         config_entry,
         process_entities_callback,
         async_add_entities,
+        True,
     )
     cem.process_entities()
+
+    dev_reg = async_get_dev_reg(hass)
+
+    async def remove_devices(event: Event) -> None:
+        """Remove devices."""
+        for mac in event.data["macs"]:
+            _LOGGER.debug("Removing device and entity for mac %s", mac)
+            device = dev_reg.async_get_device({}, {(CONNECTION_NETWORK_MAC, mac)})
+            if device:
+                dev_reg.async_remove_device(device.id)
+            cache_data.pop(mac, None)
+            await store.async_save(cache_data)
+
+    hass.bus.async_listen(
+        f"{DOMAIN}_{config_entry.entry_id}_remove_devices", remove_devices
+    )
 
 
 class PfSenseScannerEntity(PfSenseEntity, ScannerEntity):
@@ -87,27 +175,35 @@ class PfSenseScannerEntity(PfSenseEntity, ScannerEntity):
 
     def __init__(
         self,
-        config_entry,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
         coordinator: DataUpdateCoordinator,
         enabled_default: bool,
-        mac,
-        mac_vendor,
+        mac: str,
+        mac_vendor: str,
+        cache_data: dict[str, str] | None,
     ) -> None:
         """Set up the pfSense scanner entity."""
+        self.hass = hass
         self.config_entry = config_entry
         self.coordinator = coordinator
-        self._mac = mac
+        self._mac_address = mac
         self._mac_vendor = mac_vendor
         self._last_known_ip = None
+        self._cache_data = cache_data
 
         self._attr_entity_registry_enabled_default = enabled_default
-        self._attr_unique_id = slugify(f"{self.pfsense_device_unique_id}_mac_{mac}")
+        self._attr_unique_id = get_device_tracker_unique_id(
+            mac, self.pfsense_device_unique_id
+        )
 
-    def _get_pfsense_arp_entry(self):
+    def _get_pfsense_arp_entry(self) -> dict[str, str]:
         state = self.coordinator.data
         for entry in state["arp_table"]:
-            if entry.get("mac-address") == self._mac:
+            if entry.get("mac-address", "").lower() == self._mac_address:
                 return entry
+
+        return None
 
     @property
     def source_type(self) -> str:
@@ -115,7 +211,16 @@ class PfSenseScannerEntity(PfSenseEntity, ScannerEntity):
         return SOURCE_TYPE_ROUTER
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return extra state attributes."""
+        if not self.is_connected and self._cache_data:
+            return self._cache_data["extra_state_attributes"]
+
+        return self._extra_state_attributes
+
+    @property
+    def _extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return extra state attributes."""
         entry = self._get_pfsense_arp_entry()
         if entry is None:
             return None
@@ -129,6 +234,14 @@ class PfSenseScannerEntity(PfSenseEntity, ScannerEntity):
     @property
     def ip_address(self) -> str | None:
         """Return the primary ip address of the device."""
+        if not self.is_connected and self._cache_data:
+            return self._cache_data["ip_address"]
+
+        return self._ip_address
+
+    @property
+    def _ip_address(self) -> str | None:
+        """Return the primary ip address of the device."""
         entry = self._get_pfsense_arp_entry()
         if entry is None:
             return None
@@ -141,10 +254,17 @@ class PfSenseScannerEntity(PfSenseEntity, ScannerEntity):
     @property
     def mac_address(self) -> str | None:
         """Return the mac address of the device."""
-        return self._mac
+        return self._mac_address
 
     @property
     def hostname(self) -> str | None:
+        """Return hostname of the device."""
+        if not self.is_connected and self._cache_data:
+            return self._cache_data["hostname"]
+        return self._hostname
+
+    @property
+    def _hostname(self) -> str | None:
         """Return hostname of the device."""
         entry = self._get_pfsense_arp_entry()
         if entry is None:
@@ -158,8 +278,8 @@ class PfSenseScannerEntity(PfSenseEntity, ScannerEntity):
     def name(self) -> str:
         """Return the name of the device."""
         # return self.hostname or f"{self.mac_address}"
-        # return self.hostname or f"{self.pfsense_device_name} {self._mac}"
-        return self.hostname or self._mac
+        # return self.hostname or f"{self.pfsense_device_name} {self._mac_address}"
+        return self.hostname or self._mac_address
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/pfsense/device_tracker.py
+++ b/custom_components/pfsense/device_tracker.py
@@ -14,7 +14,10 @@ from homeassistant.helpers.device_registry import (
     async_get as async_get_dev_reg,
 )
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.entity_registry import async_get as async_get_ent_reg
+from homeassistant.helpers.entity_registry import (
+    DISABLED_INTEGRATION,
+    async_get as async_get_ent_reg,
+)
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify
@@ -136,7 +139,7 @@ async def async_setup_entry(
             if (
                 entity_id
                 and (entity_entry := ent_reg.async_get(entity_id))
-                and entity_entry.disabled
+                and entity_entry.disabled_by == DISABLED_INTEGRATION
             ):
                 ent_reg.async_update_entity(entity_id, disabled_by=None)
                 hass.data[DOMAIN][config_entry.entry_id][SHOULD_RELOAD] = True

--- a/custom_components/pfsense/pypfsense/__init__.py
+++ b/custom_components/pfsense/pypfsense/__init__.py
@@ -1,8 +1,8 @@
 import json
-import xmlrpc.client
-import ssl
 import socket
-from urllib.parse import urlparse, quote_plus
+import ssl
+from urllib.parse import quote_plus, urlparse
+import xmlrpc.client
 
 # value to set as the socket timeout
 DEFAULT_TIMEOUT = 5

--- a/custom_components/pfsense/sensor.py
+++ b/custom_components/pfsense/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import (  # ENTITY_CATEGORY_DIAGNOSTIC,
     STATE_UNKNOWN,
     TIME_MILLISECONDS,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify
 from homeassistant.util.dt import utc_from_timestamp
@@ -38,6 +38,7 @@ async def async_setup_entry(
 ):
     """Set up the pfSense sensors."""
 
+    @callback
     def process_entities_callback(hass, config_entry):
         data = hass.data[DOMAIN][config_entry.entry_id]
         coordinator = data[COORDINATOR]

--- a/custom_components/pfsense/strings.json
+++ b/custom_components/pfsense/strings.json
@@ -35,6 +35,12 @@
           "device_tracker_enabled": "Enable Device Tracker",
           "device_tracker_scan_interval": "Device Tracker Scan Interval (seconds)"
         }
+      },
+      "device_tracker": {
+        "description": "Choose which devices you want to track. If you don't select any devices, all devices will be tracked but will be disabled by default. If you do select any devices, only those devices will be tracked and will be enabled by default.",
+        "data": {
+          "devices": "Devices to Track"
+        }
       }
     }
   }

--- a/custom_components/pfsense/switch.py
+++ b/custom_components/pfsense/switch.py
@@ -9,7 +9,7 @@ from homeassistant.components.switch import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNKNOWN  # ENTITY_CATEGORY_CONFIG,
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify
 
@@ -26,6 +26,7 @@ async def async_setup_entry(
 ):
     """Set up the pfSense binary sensors."""
 
+    @callback
     def process_entities_callback(hass, config_entry):
         data = hass.data[DOMAIN][config_entry.entry_id]
         coordinator = data[COORDINATOR]

--- a/custom_components/pfsense/translations/en.json
+++ b/custom_components/pfsense/translations/en.json
@@ -39,6 +39,12 @@
           "device_tracker_scan_interval": "Device Tracker Scan Interval (seconds)"
         },
         "description": "Configure Options."
+      },
+      "device_tracker": {
+        "description": "Choose which devices you want to track. If you don't select any devices, all devices will be tracked but will be disabled by default. If you do select any devices, only those devices will be tracked and will be enabled by default.",
+        "data": {
+          "devices": "Devices to Track"
+        }
       }
     }
   },


### PR DESCRIPTION
- When no devices are selected, all devices are tracked but disabled by default
- When at least one device is selected, only that device is tracked and is enabled by default
- If you go from having no devices selected to selecting a device, all of the entities/devices for the devices you are no longer tracking will be removed, and if they were disabled by default, they will be enabled.
- Devices that were previously in the ARP table and thus tracked will rely on cached data on a restart so we can show the device as not connected