### PR TITLE
Update dependency version pinning to use a range

### DIFF
--- a/custom_components/pfsense/manifest.json
+++ b/custom_components/pfsense/manifest.json
@@ -7,6 +7,6 @@
   "dependencies": [],
   "codeowners": ["@travisghansen"],
   "config_flow": true,
-  "requirements": ["mac-vendor-lookup==0.1.11"],
+  "requirements": ["mac-vendor-lookup>=0.1.11"],
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
See Frenck's comments here: https://github.com/home-assistant/wheels-custom-integrations/pull/533

TLDR - core integrations (`nmap_tracker`) use this package and can update the version required for core separately which would be hard to track here. Moving to this range means that we get the bare minimum we need but we also take whatever HA installs in case another package needs a higher version

This needs to be done in order to get our wheels PR merged