### PR TITLE
Return date as datetime instead of string

### DIFF
--- a/custom_components/pfsense/sensor.py
+++ b/custom_components/pfsense/sensor.py
@@ -307,7 +307,7 @@ class PfSenseSensor(PfSenseEntity, SensorEntity):
             return STATE_UNKNOWN
 
         if self.entity_description.key == "telemetry.system.boottime":
-            value = utc_from_timestamp(value).isoformat()
+            value = utc_from_timestamp(value)
 
         if self.entity_description.key == "telemetry.cpu.frequency.current":
             if value == 0 and self._previous_value is not None:

--- a/custom_components/pfsense/sensor.py
+++ b/custom_components/pfsense/sensor.py
@@ -2,6 +2,8 @@
 import logging
 import re
 
+from awesomeversion import AwesomeVersion
+
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
     SensorEntity,
@@ -9,6 +11,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (  # ENTITY_CATEGORY_DIAGNOSTIC,
+    __version__,
     DATA_BYTES,
     DATA_RATE_KILOBYTES_PER_SECOND,
     PERCENTAGE,
@@ -308,6 +311,10 @@ class PfSenseSensor(PfSenseEntity, SensorEntity):
 
         if self.entity_description.key == "telemetry.system.boottime":
             value = utc_from_timestamp(value)
+            # For backwards compatibility we will use the string version of the
+            # datetime on systems before 2021.12.0b0
+            if AwesomeVersion(__version__) < AwesomeVersion("2021.12.0b0"):
+                value = value.isoformat()
 
         if self.entity_description.key == "telemetry.cpu.frequency.current":
             if value == 0 and self._previous_value is not None:

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "pfSense integration for Home Assistant",
   "domains": ["binary_sensor", "device_tracker", "sensor", "switch"],
+  "homeassistant": "2021.10.0",
   "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
   "name": "pfSense integration for Home Assistant",
   "domains": ["binary_sensor", "device_tracker", "sensor", "switch"],
-  "homeassistant": "2021.12.0b0",
   "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "pfSense integration for Home Assistant",
   "domains": ["binary_sensor", "device_tracker", "sensor", "switch"],
+  "homeassistant": "2021.12.0b0",
   "render_readme": true
 }


### PR DESCRIPTION
In 2021.12.0 HomeAssistant expects datetime class sensors to return date/time objects instead of a string. You can wait to merge this until the day HA is released if you want but I added a minimum version in `hacs.json` because this would break things on older versions