### PR TITLE
Add Default Gateway sensor.

### DIFF
--- a/custom_components/pfsense/__init__.py
+++ b/custom_components/pfsense/__init__.py
@@ -272,6 +272,10 @@ class PfSenseData:
         return self._client.get_interfaces()
 
     @_log_timing
+    def _get_defaultgw(self):
+        return self._client.get_defaultgw()
+
+    @_log_timing
     def _get_services(self):
         return self._client.get_services()
 
@@ -323,7 +327,7 @@ class PfSenseData:
                 message = f"failed to retrieve arp table {err=}, {type(err)=}"
                 _LOGGER.error(message)
         else:
-            # queue up the firmaware task
+            # queue up the firmware task
             # task = self._hass.loop.create_task(self._refresh_firmware_update_info())
             # self._background_tasks.add(task)
             # task.add_done_callback(self._background_tasks.discard)
@@ -333,6 +337,7 @@ class PfSenseData:
             self._state["telemetry"] = self._get_telemetry()
             self._state["config"] = self._get_config()
             self._state["interfaces"] = self._get_interfaces()
+            self._state["defaultgw"] = self._get_defaultgw()
             self._state["services"] = self._get_services()
             self._state["carp_interfaces"] = self._get_carp_interfaces()
             self._state["carp_status"] = self._get_carp_status()

--- a/custom_components/pfsense/pypfsense/__init__.py
+++ b/custom_components/pfsense/pypfsense/__init__.py
@@ -370,6 +370,13 @@ $toreturn = [
         response = self._exec_php(script)
         return response["data"]
 
+    def get_defaultgw(self):
+        gateways = self.get_gateways()
+        for g in gateways.keys():
+            if 'isdefaultgw' in gateways[g] and gateways[g]['isdefaultgw'] == True:
+                return gateways[g]['name']
+        return None
+
     def get_gateway(self, gateway):
         gateways = self.get_gateways()
         for g in gateways.keys():

--- a/custom_components/pfsense/sensor.py
+++ b/custom_components/pfsense/sensor.py
@@ -261,6 +261,19 @@ async def async_setup_entry(
                 )
                 entities.append(entity)
 
+        # default gw
+        entity = PfSenseDefaultGWSensor(
+            config_entry,
+            coordinator,
+            SensorEntityDescription(
+                key="defaultgw",
+                name="Default Gateway",
+                icon="mdi:network-outline",
+            ),
+            True,
+        )
+        entities.append(entity)
+
         # openvpn servers
         for vpnid in dict_get(state, "telemetry.openvpn.servers", {}).keys():
             servers = dict_get(state, "telemetry.openvpn.servers", {})
@@ -616,6 +629,20 @@ class PfSenseGatewaySensor(PfSenseSensor):
                 value = re.sub("[^0-9\.]*", "", value)
 
             return value
+        except KeyError:
+            return STATE_UNKNOWN
+
+
+class PfSenseDefaultGWSensor(PfSenseSensor):
+    @property
+    def native_value(self):
+        state = self.coordinator.data
+
+        if state["defaultgw"] is None:
+            return STATE_UNKNOWN
+
+        try:
+            return state["defaultgw"]
         except KeyError:
             return STATE_UNKNOWN
 


### PR DESCRIPTION
This is related to a feature request I opened here: https://github.com/travisghansen/hass-pfsense/issues/119

This uses the already existing but unused `pypfsense` `get_gateways` method.

More information: I have a Protectli Vault with pfSense loaded on it, which is connected to both my cable modem as well as an LTE modem that uses a data sim.  The gateways are configured as `WAN_DHCP` and `LTE_DHCP`, respectively.  I tested the functionality by physically unplugging the coax to the cable modem, watching pfSense switch over to the LTE modem, verifying the change in the pfSense integration, then plugging the coax back in and verifying the integration's sensor switch back to the cable modem when pfSense does.

Disclamers: My experience with Python is just surface level, and this is my first contribution to a HACs component so there's almost certainly better ways in the HASS framework to set this sensor up.  Any feedback or requests for additional testing would be appreciated, although I'm limited by the hardware I have.