### PR TITLE
Fix DHCP Sensor for New pfSense Versions

### DIFF
--- a/custom_components/pfsense/__init__.py
+++ b/custom_components/pfsense/__init__.py
@@ -354,10 +354,10 @@ class PfSenseData:
 
                     lease_stats["total"] += 1
                     if "online" in lease.keys():
-                        if lease["online"] == "online":
+                        if ("active" or "online") in lease["online"]:
                             lease_stats["online"] += 1
-                        if lease["online"] == "offline":
-                            lease_stats["offline"] += 1
+                        if "offline" in lease["online"]:
+                            lease_stats["idle_offline"] += 1
 
                 new_state["dhcp_stats"]["leases"] = lease_stats
 

--- a/custom_components/pfsense/const.py
+++ b/custom_components/pfsense/const.py
@@ -252,9 +252,9 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         state_class=STATE_CLASS_MEASUREMENT,
         # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
-    "dhcp_stats.leases.offline": SensorEntityDescription(
-        key="dhcp_stats.leases.offline",
-        name="DHCP Leases Offline",
+    "dhcp_stats.leases.idle_offline": SensorEntityDescription(
+        key="dhcp_stats.leases.idle_offline",
+        name="DHCP Leases Idle/Offline",
         native_unit_of_measurement="clients",
         icon="mdi:ip-network-outline",
         state_class=STATE_CLASS_MEASUREMENT,


### PR DESCRIPTION
They changed the strings used in reporting online/offline.

Examples of new values.

{'ip': 'xx.xx.xx.xx', 'type': 'dynamic', 'starts': '2023/02/14 17:47:30', 'ends': '2023/02/14 19:47:30', 'act': 'active', 'mac': 'xx:xx:xx:xx:xx:xx', 'online': 'active', 'hostname': 'foo'}
{'ip': 'xx.xx.xx.xx', 'type': 'dynamic', 'starts': '2023/02/14 18:00:33', 'ends': '2023/02/14 20:00:33', 'act': 'active', 'mac': 'xx:xx:xx:xx:xx:xx', 'online': 'idle/offline', 'hostname': 'bar'}