### PR TITLE
Exclude non-dictionary type rules from processing

### DIFF
--- a/custom_components/pfsense/switch.py
+++ b/custom_components/pfsense/switch.py
@@ -39,6 +39,8 @@ async def async_setup_entry(
             rules = dict_get(state, "config.filter.rule")
             if isinstance(rules, list):
                 for rule in rules:
+                    if not isinstance(rule, dict):
+                        continue
                     icon = "mdi:security-network"
                     # likely only want very specific rules to manipulate from actions
                     enabled_default = False


### PR DESCRIPTION
Ive been using this integration for about a year and the vast majority of times that HA is being restarted i used to come across this error. 

![switch pull](https://user-images.githubusercontent.com/69961224/236684273-0b2ef633-8d42-46a0-9c05-2840ef9c067c.png)

Seems like HA is getting a string-type rule from my pfsense instance which results in no further processing of interfaces traffic (inbytes_kilobytes_per_second, etc), and some other sensors and marked unavailable.

Not sure if that's a unique case somehow related to my pfsense settings.
By adding these lines everything works as intended for about a month. No further errors.