### PR TITLE
Add missing lease status of 'active/online'

### DIFF
--- a/custom_components/pfsense/__init__.py
+++ b/custom_components/pfsense/__init__.py
@@ -354,7 +354,7 @@ class PfSenseData:
 
                     lease_stats["total"] += 1
                     if "online" in lease.keys():
-                        if lease["online"] in ["active", "online"]:
+                        if lease["online"] in ["active", "active/online", "online"]:
                             lease_stats["online"] += 1
                         if lease["online"] in ["offline", "idle/offline", "idle"]:
                             lease_stats["idle_offline"] += 1


### PR DESCRIPTION
On pfSense CE 2.7.1, leases now show as another status of 'active/online'. Idle and total sensors work as expected, but online reports as zero.

<img width="1400" alt="Screenshot 2023-11-28 at 09 32 47" src="https://github.com/travisghansen/hass-pfsense/assets/170514/a7d6ea01-25ce-43a4-8c5d-1ed11ea473b7">

This quick fix adds that new status.
