### PR TITLE
Fix service calls for HA > 2025.05

### DIFF
--- a/custom_components/pfsense/services.py
+++ b/custom_components/pfsense/services.py
@@ -4,6 +4,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import async_get_platforms
+from homeassistant.helpers.service import entity_service_call
 import voluptuous as vol
 
 from .const import (

--- a/custom_components/pfsense/services.py
+++ b/custom_components/pfsense/services.py
@@ -54,8 +54,8 @@ class ServiceRegistrar:
 
         # Setup services
         async def _async_send_service(call: ServiceCall):
-            await self.hass.helpers.service.entity_service_call(
-                async_get_entities(self.hass), f"service_{call.service}", call
+            await entity_service_call(
+                self.hass, async_get_entities(self.hass), f"service_{call.service}", call
             )
 
         self.hass.services.async_register(


### PR DESCRIPTION
Using the recommendation from https://github.com/travisghansen/hass-pfsense/issues/209 this PR fixes service calls in HA > 2025.05

This fixes the error `AttributeError: 'HomeAssistant' object has no attribute 'helpers'` mentioned in https://github.com/travisghansen/hass-pfsense/issues/210