### PR TITLE
fix: OptionsFlowHandler config_entry AttributeError for HA 2025.12+

### DIFF
--- a/custom_components/pfsense/config_flow.py
+++ b/custom_components/pfsense/config_flow.py
@@ -184,16 +184,15 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle option flow for pfSense."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize options flow."""
         self.new_options = None
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""


### PR DESCRIPTION
Closes #220 

Home Assistant 2025.12+ made config_entry a read-only property in OptionsFlow. Attempting to assign it in __init__ raises AttributeError: property 'config_entry' of 'OptionsFlowHandler' object has no setter.